### PR TITLE
Add recipes index endpoint that orders by ingredientCount

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
-var recipeRouter = require('./routes/api/v1/recipes/search');
+var recipeSearchRouter = require('./routes/api/v1/recipes/search');
+var recipeRouter = require('./routes/api/v1/recipes');
 
 var app = express();
 
@@ -16,6 +17,7 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
-app.use('/api/v1/recipes/search', recipeRouter);
+app.use('/api/v1/recipes/search', recipeSearchRouter);
+app.use('/api/v1/recipes', recipeRouter);
 
 module.exports = app;

--- a/controllers/api/v1/recipes_controller.js
+++ b/controllers/api/v1/recipes_controller.js
@@ -1,0 +1,25 @@
+var Recipe = require('../../../models').Recipe;
+var RecipePresenter = require('../../../pojos/recipe_presenter.js');
+var Sequelize = require('sequelize')
+// var Op = Sequelize.Op
+
+var index = function (req, res) {
+  console.log(req.query)
+  Recipe.findAll({order: [
+    ['numIngredients', 'ASC']
+  ]
+        })
+  .then(recipe_info => {
+    let recipes = recipe_info.map(recipe => new RecipePresenter(recipe))
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).send(JSON.stringify(recipes));
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(500).send({ error });
+  })
+}
+
+module.exports = {
+  index: index
+}

--- a/routes/api/v1/recipes/index.js
+++ b/routes/api/v1/recipes/index.js
@@ -1,0 +1,7 @@
+var router = require('express').Router();
+var recipesController = require('../../../../controllers/api/v1/recipes_controller')
+
+router.get('/', recipesController.index)
+
+
+module.exports = router;

--- a/test/recipe_search_test.js
+++ b/test/recipe_search_test.js
@@ -1,0 +1,62 @@
+var assert = require('assert');
+var expect = require('chai').expect;
+var should = require('chai').should();
+var chai = require('chai');
+var chaiHttp = require('chai-http');
+var app = require('../app');
+
+chai.use(chaiHttp);
+chai.should();
+
+describe("GET /api/v1/recipes/search?food_type=chicken", () => {
+  it("should get all foods record", (done) => {
+    chai.request(app)
+    .get("/api/v1/recipes/search?food_type=chicken")
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body[0].name.split(' ').should.include('Chicken')
+      res.body[0].should.be.a('object');
+      res.body[0].should.have.property('calories')
+      res.body[0].should.have.property('name')
+      res.body[0].should.have.property('prepTime')
+      res.body[0].should.have.property('numIngredients')
+      res.body[0].should.have.property('url')
+      res.body[0].should.have.property('image')
+      res.body[0].should.have.property('cuisineType')
+      res.body[0].should.have.property('servings')
+      done();
+    });
+  });
+});
+
+describe("GET /api/v1/recipes/search?calories=200", () => {
+  it("should get all recipes below 200 calories", (done) => {
+    chai.request(app)
+    .get("/api/v1/recipes/search?calories=200")
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body[0].should.be.a('object');
+      res.body.length.should.be.above(1)
+      res.body.forEach(recipe => {
+        recipe.calories.should.be.below(200)
+      })
+      done();
+    });
+  });
+});
+
+describe("GET /api/v1/recipes/search?cuisine_type=chinese", () => {
+  it("should get all recipes with chinese cuisine type", (done) => {
+    chai.request(app)
+    .get("/api/v1/recipes/search?cuisine_type=chinese")
+    .end((err, res) => {
+      res.should.have.status(200);
+      res.body[0].should.be.a('object');
+      res.body.length.should.be.above(1)
+      res.body.forEach(recipe => {
+        recipe.cuisineType.should.equal('chinese')
+      })
+      done();
+    });
+  });
+});

--- a/test/recipe_test.js
+++ b/test/recipe_test.js
@@ -4,71 +4,22 @@ var should = require('chai').should();
 var chai = require('chai');
 var chaiHttp = require('chai-http');
 var app = require('../app');
-// var Recipe = require('../models').Recipe;
 
 chai.use(chaiHttp);
 chai.should();
 
-describe("tests set up", () => {
-  it("should work", (done) => {
+describe("GET /api/v1/recipes?sort=ingredient_count", () => {
+  it("should get all recipes record", (done) => {
     chai.request(app)
-    .get('/api/v1/foods')
-    .end((err, res) => {
-      true.should.equal(true)
-      expect(true).to.equal(true)
-      assert(false != true)
-      done();
-    });
-  });
-});
-
-describe("GET /api/v1/recipes/search?food_type=chicken", () => {
-  it("should get all foods record", (done) => {
-    chai.request(app)
-    .get("/api/v1/recipes/search?food_type=chicken")
+    .get("/api/v1/recipes?sort=ingredient_count")
     .end((err, res) => {
       res.should.have.status(200);
-      res.body[0].name.split(' ').should.include('Chicken')
-      res.body[0].should.be.a('object');
-      res.body[0].should.have.property('calories')
-      res.body[0].should.have.property('name')
-      res.body[0].should.have.property('prepTime')
-      res.body[0].should.have.property('numIngredients')
-      res.body[0].should.have.property('url')
-      res.body[0].should.have.property('image')
-      res.body[0].should.have.property('cuisineType')
-      res.body[0].should.have.property('servings')
-      done();
-    });
-  });
-});
-
-describe("GET /api/v1/recipes/search?calories=200", () => {
-  it("should get all recipes below 200 calories", (done) => {
-    chai.request(app)
-    .get("/api/v1/recipes/search?calories=200")
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body[0].should.be.a('object');
-      res.body.length.should.be.above(1)
-      res.body.forEach(recipe => {
-        recipe.calories.should.be.below(200)
-      })
-      done();
-    });
-  });
-});
-
-describe("GET /api/v1/recipes/search?cuisine_type=chinese", () => {
-  it("should get all recipes with chinese cuisine type", (done) => {
-    chai.request(app)
-    .get("/api/v1/recipes/search?cuisine_type=chinese")
-    .end((err, res) => {
-      res.should.have.status(200);
-      res.body[0].should.be.a('object');
-      res.body.length.should.be.above(1)
-      res.body.forEach(recipe => {
-        recipe.cuisineType.should.equal('chinese')
+      res.body.length.should.equal(396)
+      console.log(res.body)
+      res.body.forEach(function(recipe,index,recipes) {
+        if(recipes[index-1]){ //do not compare zeroith index with negative first index
+        assert(recipe.numIngredients >= recipes[index-1].numIngredients)
+      }
       })
       done();
     });


### PR DESCRIPTION
## What functionality does this accomplish?
closes #
​
**Description:**
​Adds api/v1/recipes index to show recipes ordered by ingredient count, needed for story #38
​
## What did you struggle on to complete?
​
​Realizing we needed a separately name-spaced controller and couldn't use the endpoints we built out
​
## Current Test Suite:
### Test Coverage Percentage: 93%
- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):
​
## Checklist:
- [ ] My code has no unused/commented out code
- [ ] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [ ] I have partially tested my code (please explain why):
​
## Helpful Resources:
* Resource link AND small description of info gathered/learned

https://sequelize.org/master/manual/querying.html#ordering sequelize ordering docs
